### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Create the release
-      uses: elgohr/Github-Release-Action@v3.1
+      uses: elgohr/Github-Release-Action@v4
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore